### PR TITLE
Support Rails 6.0 and 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Build Status](https://secure.travis-ci.org/bernat/best_in_place.png)](http://travis-ci.org/bernat/best_in_place)
 **The Unobtrusive in Place editing solution**
 
-**NB**: For Rails >= 6.1 you can install the gem from this repository with:
+**NB**: For Rails >= 6.0 you can install the gem from this repository with:
 
-    gem "best_in_place", git: "https://github.com/mmotherwell/best_in_place"
+    gem "best_in_place", git: "https://github.com/readyfor/best_in_place", branch: "rails-6"
 
 ## Description
 

--- a/lib/best_in_place/engine.rb
+++ b/lib/best_in_place/engine.rb
@@ -1,8 +1,11 @@
 module BestInPlace
   class Engine < Rails::Engine
     initializer 'best_in_place' do
-      ActionView::Base.send(:include, BestInPlace::Helper)
-      ActionController::Base.send(:include, BestInPlace::ControllerExtensions)
+      ActiveSupport.on_load(:action_controller) do
+        ActionView::Base.send(:include, BestInPlace::Helper)
+
+        ActionController::Base.send(:include, BestInPlace::ControllerExtensions)
+      end
     end
   end
 end

--- a/lib/best_in_place/railtie.rb
+++ b/lib/best_in_place/railtie.rb
@@ -4,7 +4,7 @@ require 'action_view/base'
 module BestInPlace
   class Railtie < ::Rails::Railtie #:nodoc:
     config.after_initialize do
-      BestInPlace::ViewHelpers = ActionView::Base.new({}, {}, "")
+      BestInPlace::ViewHelpers = ActionView::Base.respond_to?(:empty) ? ActionView::Base.empty : ActionView::Base.new
     end
   end
 end


### PR DESCRIPTION
[The latest version(v3.1.1) of best_in_place](https://rubygems.org/gems/best_in_place/versions/3.1.1) published on rubygems.org has the following deprecation warning on Rails 6.0.
```
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. (called from <main> at /app/config/environment.rb:5)
```

This is fixed in the master branch(a3560e874444af8b2cf78419dc5eef020626c93c), and it work well with Rails 6.1. But it does not work well with Rails 6.0.
https://github.com/readyfor/best_in_place/compare/v3.1.1...a3560e874444af8b2cf78419dc5eef020626c93c

The changes in this PR make work well with Rails 6.0 and 6.1.
